### PR TITLE
Allow to be interpreted as a Python CLI tool

### DIFF
--- a/libpyclingo-dl/clingodl/__main__.py
+++ b/libpyclingo-dl/clingodl/__main__.py
@@ -99,5 +99,12 @@ class ClingoDLApp(Application):
         return symbol.type == SymbolType.Function and symbol.name.startswith("__")
 
 
-if __name__ == "__main__":
+def main():
+    """
+    Main function to be used as an entry point.
+    """
     sys.exit(int(clingo_main(ClingoDLApp("clingo-dl"), sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     python_requires=">=3.6",
     entry_points={
         'console_scripts': [
-            'clingo-dl=clingodl.__main__:main',
+            'pyclingo-dl=clingodl.__main__:main',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,10 @@ setup(
     packages=[ 'clingodl' ],
     package_data={ 'clingodl': [ 'py.typed', 'import__clingo-dl.lib', 'clingo-dl.h' ] },
     package_dir={ '': 'libpyclingo-dl' },
-    python_requires=">=3.6"
+    python_requires=">=3.6",
+    entry_points={
+        'console_scripts': [
+            'clingo-dl=clingodl.__main__:main',
+        ],
+    },
 )


### PR DESCRIPTION
The current setup definition was not allowing tools such as `pipx` to detect clingo-dl as a CLI tool. With this change it can now be properly detected.

This means that:
- You can install it using `pipx install clingo-dl`
- After installing, you can run it as `clingo-dl <your_arguments>`