### PR TITLE
use clasp's output API to nicely print assignments

### DIFF
--- a/lib/c-api/src/clingo-dl.cc
+++ b/lib/c-api/src/clingo-dl.cc
@@ -29,7 +29,6 @@
 #include <clingo/propagate.hh>
 
 #include <array>
-#include <sstream>
 
 using namespace ClingoDL;
 
@@ -579,7 +578,6 @@ struct clingodl_theory {
     bool shift_constraints{false};
 
     static auto info([[maybe_unused]] void *self, clingo_string_t *name, int *major, int *minor, int *patch) -> bool {
-        using namespace std::string_view_literals;
         CLINGO_TRY {
             if (name != nullptr) {
                 constexpr auto str = "clingo-dl"sv;
@@ -654,7 +652,6 @@ struct clingodl_theory {
     static auto register_options(void *self, clingo_options_t *options) -> bool {
         auto theory = static_cast<clingodl_theory *>(self);
         CLINGO_TRY {
-            using namespace std::string_view_literals;
             auto group = "Clingo.DL Options"sv;
             auto opt = [&](std::string_view name, std::string_view desc, clingo_option_parser_t parser,
                            bool multi = false, std::string_view arg = {}) {
@@ -675,6 +672,11 @@ struct clingodl_theory {
             flag("rdl", desc_rdl, theory->rdl);
             flag("shift-constraints", desc_shift, theory->shift_constraints);
             flag("compute-components", desc_comp, theory->config.calculate_cc);
+
+            static constexpr auto assign = "out-assign"sv;
+            static constexpr auto assign_val = "__dl/2"sv;
+            Clingo::Detail::handle_error(clingo_options_set_default_value(options, assign.data(), assign.size(),
+                                                                          assign_val.data(), assign_val.size()));
         }
         CLINGO_CATCH;
     }

--- a/lib/optimizer/tests/optimize.cc
+++ b/lib/optimizer/tests/optimize.cc
@@ -50,7 +50,7 @@ struct Fixture : public Clingo::SolveEventHandler {
 
     //! Create symbols representing DL assignments.
     auto assign(Clingo::Symbol const &name, int value) -> Clingo::Symbol {
-        return Clingo::Function(lib, "dl", {name, Clingo::Number(value)});
+        return Clingo::Function(lib, "__dl", {name, Clingo::Number(value)});
     }
 
     //! Run the optimization algorithm minimizing the given variable.

--- a/lib/python-api/tests/test_solve.py
+++ b/lib/python-api/tests/test_solve.py
@@ -36,6 +36,6 @@ def test_solve():
 
     ctl.solve(on_model=on_model)
 
-    assert models == [(["a", "b", "c", "dl(x,0)", "dl(y,1)"], [("x", 0), ("y", 1)])]
+    assert models == [(["__dl(x,0)", "__dl(y,1)", "a", "b", "c"], [("x", 0), ("y", 1)])]
 
     gc.collect()

--- a/lib/solver/src/propagator.cc
+++ b/lib/solver/src/propagator.cc
@@ -148,7 +148,7 @@ template <typename T> void DLPropagator<T>::extend_model(Clingo::Model &model) {
             T adjust = state.graph.has_value(zero_vertex) ? state.graph.get_value(zero_vertex) : 0;
             params.emplace_back(vertex_info_[idx].symbol);
             params.emplace_back(to_symbol<T>(lib_, state.graph.get_value(idx) - adjust));
-            vec.emplace_back(Function(lib_, "dl", params));
+            vec.emplace_back(Function(lib_, "__dl", params));
         }
     }
     model.extend(vec);

--- a/lib/solver/tests/propagator.cc
+++ b/lib/solver/tests/propagator.cc
@@ -50,7 +50,11 @@ template <class N> class MCB : public Clingo::SolveEventHandler {
         }
         models_->emplace_back();
         for (auto &sym : model.symbols(Clingo::ShowFlags::shown)) {
-            models_->back().push_back(sym.to_string());
+            if (sym.name() == "__dl") {
+                models_->back().push_back(sym.to_string().erase(0, 2));
+            } else {
+                models_->back().push_back(sym.to_string());
+            }
         }
         std::ranges::sort(models_->back());
         return true;


### PR DESCRIPTION
This PR integrates with clasp's output API to improve how difference logic assignments are displayed. The key changes involve renaming the output function from "dl" to "__dl" and configuring clasp to recognize this function for formatted output.

- Changed the function name used for model extension from "dl" to "__dl" in the propagator
- Added configuration to set "__dl/2" as the default value for the "out-assign" option in clasp
- Adjusted tests to work with modified symbol name

| File | Description |
| ---- | ----------- |
| lib/solver/src/propagator.cc | Updated function name from "dl" to "__dl_assign" in the extend_model method |
| lib/c-api/src/clingo-dl.cc | Added configuration to set default value for clasp's out-assign option to recognize __dl_assign/2 |